### PR TITLE
Parallelize samples generation

### DIFF
--- a/app/Config.hs
+++ b/app/Config.hs
@@ -6,6 +6,7 @@ data Config
     = Config
         { output    :: Maybe String
         , onlyCheck :: Bool
+        , cores     :: Int
         , files     :: [String]
         }
     deriving Show
@@ -22,4 +23,10 @@ config =
     <*> switch
         ( long "check"
        <> help "Check that song is valid without producing the WAV" )
+    <*> option auto
+        ( short 'j'
+       <> help "Number of cores to run on"
+       <> showDefault
+       <> value 2
+       <> metavar "INT")
     <*> some (argument str (metavar "FILES..."))

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -7,6 +7,7 @@ module Main where
 import           System.Exit
 import           System.IO
 
+import           Control.Concurrent
 import           Control.Monad
 
 import           Data.Bifunctor
@@ -47,6 +48,8 @@ main = runOctune =<< execParser opts
 -- Currently compiles exactly 1 song per file
 runOctune :: Config -> IO ()
 runOctune cfg = do
+    setNumCapabilities (cores cfg)
+
     let fileNames = files cfg
     fileContents <- traverse TIO.readFile fileNames
     case fileContents of

--- a/octune.cabal
+++ b/octune.cabal
@@ -57,6 +57,7 @@ library
     , either
     , lens
     , megaparsec
+    , monad-par
     , optparse-applicative
     , text
   default-language: Haskell2010
@@ -68,7 +69,7 @@ executable octune
       Paths_octune
   hs-source-dirs:
       app
-  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N1
+  ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N2 -O2
   build-depends:
       WAVE
     , base >=4.7 && <5
@@ -76,6 +77,7 @@ executable octune
     , either
     , lens
     , megaparsec
+    , monad-par
     , octune
     , optparse-applicative
     , text
@@ -96,6 +98,7 @@ test-suite octune-test
     , either
     , lens
     , megaparsec
+    , monad-par
     , octune
     , optparse-applicative
     , text

--- a/package.yaml
+++ b/package.yaml
@@ -28,6 +28,7 @@ dependencies:
 - megaparsec
 - WAVE
 - optparse-applicative
+- monad-par
 
 library:
   source-dirs: src
@@ -42,7 +43,8 @@ executables:
     ghc-options:
     - -threaded
     - -rtsopts
-    - -with-rtsopts=-N1
+    - -with-rtsopts=-N2
+    - -O2
     dependencies:
     - octune
 


### PR DESCRIPTION
Samples generation can now be done in parallel!
- Added option `-jN` for using `N` cores (defaulted to 2)
- For typical use cases, running with 2 and 4 cores leads to speedups of factors of 1.2 and 1.35 respectively compared to before